### PR TITLE
Create NumFocus-affiliated-projects.md

### DIFF
--- a/decisions/NumFocus-affiliated-projects.md
+++ b/decisions/NumFocus-affiliated-projects.md
@@ -1,0 +1,45 @@
+---
+# Configuration for the Jekyll template "Just the Docs"
+parent: Decisions
+nav_order: 1
+title: Template
+layout: home
+
+# These are optional elements. Feel free to remove any of them.
+# status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
+# date: {YYYY-MM-DD when the decision was last updated}
+# deciders: {list everyone involved in the decision}
+# consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+# informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+<!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
+<!-- markdownlint-disable-next-line MD025 -->
+# Apply for affiliated-projects within NumFocus 
+
+## Context and Problem Statement
+Being part of NumFocus has a few advantages: 1) financial support 2) increased exposure in the community 3) being part of a wider ecosystem.
+
+We can use the small development grant to run workshops. 
+
+## Considered Options
+
+### Apply collectively as MP or individually for each library 
+We agree it's better to apply collectively for the reasons below: 
+1) users generally use MP codes as a whole
+2) it requires less sustained application efforts 
+3) there are precedence where a collection of codes is an affiliated project and apply for seperate funding for individual development effort 
+
+### Interests in participation from individual libraries  
+We tentatively assume all MP codes are included unless maintainers of specific libraries want to opt out. 
+
+## Decision Outcome
+
+
+
+## Implementation Plan
+- @yang-ruoxi will inquire NumFocus about their guidelines
+- Once hear back, a subcomittee of interested parties can draft an application before Jan 15 2025
+
+
+## More Information
+https://numfocus.org/sponsored-projects/affiliated-projects

--- a/decisions/NumFocus-affiliated-projects.md
+++ b/decisions/NumFocus-affiliated-projects.md
@@ -34,11 +34,13 @@ We tentatively assume all MP codes are included unless maintainers of specific l
 
 ## Decision Outcome
 
+- Following @yang-ruoxi  discussions with NumFocus, it's clear we should apply as MPSF rather than as individual packages
+- @yang-ruoxi and @rkingsbury drafted an application to be submitted for the April 15th deadline
+- At the March 2025 MPSF meeting, the members present decided to proceed to apply.
 
 
 ## Implementation Plan
-- @yang-ruoxi will inquire NumFocus about their guidelines
-- Once hear back, a subcomittee of interested parties can draft an application before Jan 15 2025
+- @yang-ruoxi will coordinate finalizing and submitting the NumFocus application
 
 
 ## More Information


### PR DESCRIPTION
# Apply for affiliated-projects within NumFocus 

## Context and Problem Statement
Being part of NumFocus has a few advantages: 1) financial support 2) increased exposure in the community 3) being part of a wider ecosystem.

We can use the small development grant to run workshops. 

## Considered Options

### Apply collectively as MP or individually for each library 
We agree it's better to apply collectively for the reasons below: 
1) users generally use MP codes as a whole
2) it requires less sustained application efforts 
3) there are precedence where a collection of codes is an affiliated project and apply for seperate funding for individual development effort 

### Interests in participation from individual libraries  
We tentatively assume all MP codes are included unless maintainers of specific libraries want to opt out. 

## Decision Outcome

- Following @yang-ruoxi  discussions with NumFocus, it's clear we should apply as MPSF rather than as individual packages
- @yang-ruoxi and @rkingsbury drafted an application to be submitted for the April 15th deadline
- At the March 2025 MPSF meeting, the members present decided to proceed to apply.



## Implementation Plan
- @yang-ruoxi will coordinate finalizing and submitting the NumFocus application


## More Information
https://numfocus.org/sponsored-projects/affiliated-projects